### PR TITLE
[FEAT] Use GoGelf v2 library and refact current code

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,17 @@ GLB GELF is a Go library used for structured log messages generation. They could
 Installation
 ----------
 
+Using version 1.0.0
+
 ```shell
+go get github.com/Graylog2/go-gelf/gelf
+go get github.com/globocom/glbgelf
+```
+
+Using version 2.0.0
+
+```shell
+go get gopkg.in/Graylog2/go-gelf.v2/gelf
 go get github.com/globocom/glbgelf
 ```
 

--- a/README.md
+++ b/README.md
@@ -6,15 +6,6 @@ GLB GELF is a Go library used for structured log messages generation. They could
 Installation
 ----------
 
-Using version 1.0.0
-
-```shell
-go get github.com/Graylog2/go-gelf/gelf
-go get github.com/globocom/glbgelf
-```
-
-Using version 2.0.0
-
 ```shell
 go get gopkg.in/Graylog2/go-gelf.v2/gelf
 go get github.com/globocom/glbgelf

--- a/glbgelf.go
+++ b/glbgelf.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Graylog2/go-gelf/gelf"
+	"gopkg.in/Graylog2/go-gelf.v2/gelf"
 )
 
 var (
@@ -21,7 +21,7 @@ var (
 
 // Gelf struct
 type Gelf struct {
-	writer      *gelf.Writer
+	writer      *gelf.UDPWriter
 	appName     string
 	tags        string
 	hostname    string
@@ -106,7 +106,6 @@ func (g *Gelf) SendLog(extra map[string]interface{}, loglevel string, messages .
 
 // InitLogger Initialize logger with Info Debug and Error
 func InitLogger(graylogAddr string, appName string, tags string, development bool) {
-	var gelfWriter *gelf.Writer
 	var err error
 
 	if graylogAddr == "" {
@@ -118,7 +117,7 @@ func InitLogger(graylogAddr string, appName string, tags string, development boo
 		graylogAddr = envAddr
 	}
 	log.Println("Graylog server: ", graylogAddr)
-	gelfWriter, err = gelf.NewWriter(graylogAddr)
+	gelfWriter, err := gelf.NewUDPWriter(graylogAddr)
 	if err != nil {
 		log.Fatalf("gelf.NewWriter error: %s", err)
 	}


### PR DESCRIPTION
Using current v2 GoGelf library. It enables TCP or UDP transport protocol selection.

Refactoring code so we can use the `UDPWriter` struct. In the future, we may choose between TCP or UDP protocol.
