### PR TITLE
[FIX] Include go get command for GoGelf dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Installation
 ----------
 
 ```shell
+go get github.com/Graylog2/go-gelf/gelf
 go get github.com/globocom/glbgelf
 ```
 


### PR DESCRIPTION
It is necessary install the current dependency to our library work properly.