### PR TITLE
[FEAT] TCP Support in Graylog connection establishment

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,17 @@ GLB GELF is a Go library used for structured log messages generation. They could
 Installation
 ----------
 
+Using version 1.0.0
+
 ```shell
+go get github.com/Graylog2/go-gelf/gelf
+go get github.com/globocom/glbgelf
+```
+
+Using version 2.0.0
+
+```shell
+go get gopkg.in/Graylog2/go-gelf.v2/gelf
 go get github.com/globocom/glbgelf
 ```
 

--- a/glbgelf.go
+++ b/glbgelf.go
@@ -20,7 +20,7 @@ var (
 
 // Gelf struct
 type Gelf struct {
-	writer      interface{}
+	writer      gelf.Writer
 	appName     string
 	tags        string
 	hostname    string
@@ -101,37 +101,31 @@ func (g *Gelf) SendLog(extra map[string]interface{}, loglevel string, messages .
 		return nil
 	}
 
-	if strings.EqualFold(g.protocol, "tcp") {
-		return g.writer.(*gelf.TCPWriter).WriteMessage(m)
-	} else {
-		gUDPWriter := g.writer.(*gelf.UDPWriter)
-		gUDPWriter.CompressionType = 2
-		return gUDPWriter.WriteMessage(m)
-	}
+	return g.writer.WriteMessage(m)
 }
 
 // It will return the correct gelfWriter based on the chosen transport protocol
-func GetWriter(protocol, graylogAddr string) (interface{}, error) {
-
-	var err error
-	var gelfWriter interface{}
+func GetWriter(protocol, graylogAddr string) (gelf.Writer, error) {
 
 	if strings.EqualFold(protocol, "tcp") {
-		gelfWriter, err = gelf.NewTCPWriter(graylogAddr)
-		return gelfWriter, err
+		return gelf.NewTCPWriter(graylogAddr)
 	}
 	if strings.EqualFold(protocol, "udp") {
-		gelfWriter, err = gelf.NewUDPWriter(graylogAddr)
-		return gelfWriter, err
+		gelfUDPWriter, err := gelf.NewUDPWriter(graylogAddr)
+		if err != nil {
+			return gelfUDPWriter, err
+		}
+		gelfUDPWriter.CompressionType = 2
+		return gelfUDPWriter, nil
 	}
 	errMessage := "Invalid Transport Protocol " + protocol
-	return gelfWriter, errors.New(errMessage)
+	return nil, errors.New(errMessage)
 }
 
 // InitLogger Initialize logger with Info Debug and Error
 func InitLogger(graylogAddr string, appName string, tags string, development bool, protocol string) {
 	var err error
-	var gelfWriter interface{}
+	var gelfWriter gelf.Writer
 
 	if graylogAddr == "" {
 		envAddr, ok := os.LookupEnv("GELF_GRAYLOG_SERVER")

--- a/glbgelf.go
+++ b/glbgelf.go
@@ -110,11 +110,12 @@ func InitLogger(graylogAddr string, appName string, tags string, development boo
 	var err error
 
 	if graylogAddr == "" {
-		graylogAddr, ok := os.LookupEnv("GELF_GRAYLOG_SERVER")
-		if (!ok && !development) || (graylogAddr == "" && !development) {
+		envAddr, ok := os.LookupEnv("GELF_GRAYLOG_SERVER")
+		if (!ok && !development) || (envAddr == "" && !development) {
 			log.Fatalf("Error! Graylog server not defined.")
 			return
 		}
+		graylogAddr = envAddr
 	}
 	log.Println("Graylog server: ", graylogAddr)
 	gelfWriter, err = gelf.NewWriter(graylogAddr)
@@ -129,19 +130,21 @@ func InitLogger(graylogAddr string, appName string, tags string, development boo
 	}
 
 	if appName == "" {
-		appName, ok := os.LookupEnv("GELF_APP_NAME")
-		if !ok || appName == "" {
-			appName = "undefined"
+		envApp, ok := os.LookupEnv("GELF_APP_NAME")
+		if !ok || envApp == "" {
+			envApp = "undefined"
 			log.Println("Nome de app nao definido. Usando undefined.")
 		}
+		appName = envApp
 	}
 
 	if tags == "" {
-		tags, ok := os.LookupEnv("GELF_TAGS")
-		if !ok || tags == "" {
-			tags = appName
+		envTags, ok := os.LookupEnv("GELF_TAGS")
+		if !ok || envTags == "" {
+			envTags = appName
 			log.Println("Tags not defined. Using appName.")
 		}
+		tags = envTags
 	}
 
 	gelfWriter.CompressionType = 2

--- a/glbgelf.go
+++ b/glbgelf.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Graylog2/go-gelf/gelf"
+	"gopkg.in/Graylog2/go-gelf.v2/gelf"
 )
 
 var (
@@ -21,7 +21,7 @@ var (
 
 // Gelf struct
 type Gelf struct {
-	writer      *gelf.Writer
+	writer      *gelf.UDPWriter
 	appName     string
 	tags        string
 	hostname    string
@@ -106,7 +106,6 @@ func (g *Gelf) SendLog(extra map[string]interface{}, loglevel string, messages .
 
 // InitLogger Initialize logger with Info Debug and Error
 func InitLogger(graylogAddr string, appName string, tags string, development bool) {
-	var gelfWriter *gelf.Writer
 	var err error
 
 	if graylogAddr == "" {
@@ -118,7 +117,7 @@ func InitLogger(graylogAddr string, appName string, tags string, development boo
 		graylogAddr = envAddr
 	}
 	log.Println("Graylog server: ", graylogAddr)
-	gelfWriter, err = gelf.NewWriter(graylogAddr)
+	gelfWriter, err := gelf.NewUDPWriter(graylogAddr)
 	if err != nil {
 		log.Fatalf("gelf.NewWriter error: %s", err)
 	}

--- a/glbgelf.go
+++ b/glbgelf.go
@@ -65,7 +65,6 @@ func (g *Gelf) SendLog(extra map[string]interface{}, loglevel string, messages .
 		strextra[i] = fmt.Sprintf("%s:%v", k, v)
 		i++
 	}
-	// Info.Printf("%s %s\n", strings.Join(strextra, " "), message)
 	_, file, line, _ := runtime.Caller(1)
 	extras := map[string]interface{}{
 		"file": file,
@@ -96,7 +95,6 @@ func (g *Gelf) SendLog(extra map[string]interface{}, loglevel string, messages .
 
 	jsonLog := mBuf.Bytes()
 
-	// TODO: VERIFICAR COMO O JSON E PRINTADO! IDEAL E Q SEJA EM UMA LINHA APENAS! NAO PRINTAR EM LINHAS SEPARADAS!
 	log.Println(string(jsonLog))
 
 	if g.development {


### PR DESCRIPTION
With GoGelf v2, it supports both TCP and UDP protocols. Our lib will choose the correct gelfWriter based on the chosen transport protocol.